### PR TITLE
allow setting DB_CHARSET in .env

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -20,6 +20,7 @@ if [[ ! -f "${APP_ROOT}/index.php" ]]; then
         sed -i "s/username_here/${DB_USER:-wordpress}/" "${APP_ROOT}/wp-config.php"
         sed -i "s/password_here/${DB_PASSWORD:-wordpress}/" "${APP_ROOT}/wp-config.php"
         sed -i "s/'DB_HOST', 'localhost'/'DB_HOST', '${DB_HOST:-mariadb}'/" "${APP_ROOT}/wp-config.php"
+        sed -i "s/'DB_CHARSET', 'utf8'/'DB_CHARSET', '${DB_CHARSET:-utf8}'/" "${APP_ROOT}/wp-config.php"
         echo "define('FS_METHOD', 'direct');" >> "${APP_ROOT}/wp-config.php"
     fi
 else


### PR DESCRIPTION
I prefer to set my DB_CHARSET to utf8mb4 as this has been the WordPress default since 4.2 (https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/). See also https://github.com/roots/bedrock/issues/230. It would be nice to expose that as an .env variable!